### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
     "GPL-2.0"
   ],
   "require": {
-    "robloach/component-installer": "*"
+    "components/jquery": "*"
   }
 }


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package manager for PHP. This allows jQuery Details to be downloaded by putting `"mathiasbynens/jquery-details"` in your own `composer.json` file:

``` json
{
  "require": {
    "mathiasbynens/jquery-details": "0.1.*"
  }
}
```
