### PR TITLE
Make sure click handler on summary element is only bound once.

### DIFF
--- a/jquery.details.js
+++ b/jquery.details.js
@@ -82,7 +82,7 @@
 					'role': 'button',
 					'aria-expanded': $details.prop('open'),
 					'aria-controls': $details.attr('id')
-				}).on('click', function() {
+				}).off('click.details').on('click.details', function() {
 					// the value of the `open` property is the old value
 					var close = $details.prop('open');
 					$summary.attr('aria-expanded', !close);
@@ -137,7 +137,7 @@
 				toggleOpen($details, $detailsSummary, $detailsNotSummary);
 
 				// Add `role=button` and set the `tabindex` of the `summary` element to `0` to make it keyboard accessible
-				$detailsSummary.attr({'role': 'button', 'aria-controls': $details.attr('id')}).noSelect().prop('tabIndex', 0).on('click', function() {
+				$detailsSummary.attr({'role': 'button', 'aria-controls': $details.attr('id')}).noSelect().prop('tabIndex', 0).off('click.details').on('click.details', function() {
 					// Focus on the `summary` element
 					$detailsSummary.focus();
 					// Toggle the `open` and `aria-expanded` attributes and the `open` property of the `details` element and display the additional info


### PR DESCRIPTION
If you run something like `$('details').details();` twice on a page, it will bind the click handler twice, causing the details element to both open and close when clicked, thus returning to its pre-click state. I.e. it looks like the nothing has happened.
Added namespace to click event to avoid collision with other event handlers.
