### PR TITLE
Do not trigger on summary > a, summary > button

### DIFF
--- a/jquery.details.js
+++ b/jquery.details.js
@@ -127,10 +127,15 @@
 
 				// Add `role=button` and set the `tabindex` of the `summary` element to `0` to make it keyboard accessible
 				$detailsSummary.attr('role', 'button').noSelect().prop('tabIndex', 0).on('click', function() {
-					// Focus on the `summary` element
-					$detailsSummary.focus();
-					// Toggle the `open` and `aria-expanded` attributes and the `open` property of the `details` element and display the additional info
-					toggleOpen($details, $detailsSummary, $detailsNotSummary, true);
+
+					// Do not trigger on link or button elements
+					if (!$(evt.target).parentsUntil($detailsSummary).add($(evt.target)).is('a, button')) {
+						// Focus on the `summary` element
+						$detailsSummary.focus();
+						// Toggle the `open` and `aria-expanded` attributes and the `open` property of the `details` element and display the additional info
+						toggleOpen($details, $detailsSummary, $detailsNotSummary, true);
+					}
+
 				}).keyup(function(event) {
 					if (32 == event.keyCode || (13 == event.keyCode && !isOpera)) {
 						// Space or Enter is pressed — trigger the `click` event on the `summary` element


### PR DESCRIPTION
The spec for the summary element states that it can contain links. When clicking on a link though, the details should not be shown if the link is meant to be clicked (as that probably be unintended behaviour). This patch - while not particularly superclean - prevents opening the details box if the element that's been clicked or one of its ancestors is a button or a link.
