### PR TITLE
Add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jquery-details",
+  "version": "0.0.1",
+  "description": "polyfills `<details>`/`<summary>` HTML elements and adds the appropriate ARIA annotations for optimal accessibility",
+  "main": "jquery.details.js",
+  "repository": "github:mathiasbynens/jquery-details",
+  "files": ["jquery.details.js"],
+  "keywords": ["jquery", "details", "summary", "polyfill"],
+  "author": "Mathias Bynens",
+  "license": "MIT"
+}


### PR DESCRIPTION
This adds a package.json file so that it can be published by npm and consumed by tooling like browserify, etc. [npm is now the recommended registry since the jquery-plugin registry closed.](http://plugins.jquery.com/)

Thanks for the great module! Would appreciate a publish.
